### PR TITLE
Add DKMS support

### DIFF
--- a/XDMA/linux-kernel/dkms/README.md
+++ b/XDMA/linux-kernel/dkms/README.md
@@ -1,0 +1,14 @@
+# Install XDMA module using DKMS
+
+The `xdma` module can also be built using [DKMS (Dynamic Kernel Module Support)](https://wiki.debian.org/KernelDKMS).
+When building and installing the driver this way, it will be automatically updated when a newer kernel version is installed using `apt`.
+
+To add the driver to DKMS, and subsequently build and install it, run
+```
+$ sudo ./install.sh
+```
+To load the driver, insert it using `modprobe`:
+```
+$ sudo modprobe xdma
+```
+To always load the driver at boot time, add `ifc_uio` to `/etc/modules`.

--- a/XDMA/linux-kernel/dkms/dkms.conf
+++ b/XDMA/linux-kernel/dkms/dkms.conf
@@ -1,0 +1,13 @@
+PACKAGE_NAME=xdma
+PACKAGE_VERSION=2020.2.2-0
+
+# MAKE="make -C xdma BUILDSYSTEM_DIR=${kernel_source_dir} "
+# CLEAN="make -C xdma clean"
+MAKE[0]="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build/xdma"
+CLEAN="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build/xdma clean"
+
+BUILT_MODULE_LOCATION="xdma"
+BUILT_MODULE_NAME="xdma"
+DEST_MODULE_LOCATION=/updates
+
+AUTOINSTALL=yes

--- a/XDMA/linux-kernel/dkms/install.sh
+++ b/XDMA/linux-kernel/dkms/install.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -e
+set -u
+
+# Change working directory to script directory.
+script_dir="$(dirname $(realpath "$0"))"
+cd "$script_dir" || exit 1
+
+# Get package name and version from 'dkms.conf'.
+package_name="$(grep '^PACKAGE_NAME' dkms.conf | cut -d'=' -f2)"
+package_version="$(grep '^PACKAGE_VERSION' dkms.conf | cut -d'=' -f2)"
+
+# Install the sources.
+src_dir="/usr/src/${package_name}-${package_version}"
+rm -rf "$src_dir"
+mkdir "$src_dir"
+cp -v -r ../include ../xdma "$src_dir"
+cp -v ../COPYING ../LICENSE ../readme.txt ../RELEASE "$src_dir"
+cp -v ./dkms.conf "$src_dir"
+
+# Enable command echo.
+set -x
+
+# Remove the module from the DKMS tree if it was previously there.
+dkms remove -m "$package_name" -v "$package_version" --all || true
+
+# Add the module to the DKMS tree.
+dkms add -m "$package_name" -v "$package_version"
+dkms build -m "$package_name" -v "$package_version"
+dkms install -m "$package_name" -v "$package_version"
+
+cat << EOF
+###########################################################
+
+    Module 'xdma' installed. Load using
+
+    $ sudo modprobe xdma
+
+###########################################################
+EOF


### PR DESCRIPTION
This patch enables enrolling the XDMA driver with DKMS (Dynamic Kernel Module Support), automating driver rebuilds when the kernel is updated.